### PR TITLE
ai_dynamic_skill fixes for dedicated servers

### DIFF
--- a/addons/ai_dynamic_skill/config.cpp
+++ b/addons/ai_dynamic_skill/config.cpp
@@ -36,21 +36,21 @@ class Extended_Init_Eventhandlers {
 class Extended_GetInMan_Eventhandlers {
     class CAManBase {
         class AI_Dynamic_Skill {
-            getinman = "(_this select 0) call AI_Dynamic_Skill_fnc_updateSkills";
+            getinman = "isNil { (_this select 0) call AI_Dynamic_Skill_fnc_updateSkills }";
         };
     };
 };
 class Extended_GetOutMan_Eventhandlers {
     class CAManBase {
         class AI_Dynamic_Skill {
-            getoutman = "(_this select 0) call AI_Dynamic_Skill_fnc_updateSkills";
+            getoutman = "isNil { (_this select 0) call AI_Dynamic_Skill_fnc_updateSkills }";
         };
     };
 };
 class Extended_SeatSwitchedMan_Eventhandlers {
     class CAManBase {
         class AI_Dynamic_Skill {
-            seatswitchedman = "(_this select 0) call AI_Dynamic_Skill_fnc_updateSkills";
+            seatswitchedman = "isNil { (_this select 0) call AI_Dynamic_Skill_fnc_updateSkills }";
         };
     };
 };

--- a/addons/ai_dynamic_skill/config.cpp
+++ b/addons/ai_dynamic_skill/config.cpp
@@ -22,6 +22,7 @@ class CfgFunctions {
             class updateSkills;
             class watchSkills { postInit = 1; };
             class currentSkills;
+            class scheduleInitSkills;
         };
     };
 };
@@ -29,7 +30,7 @@ class CfgFunctions {
 class Extended_Init_Eventhandlers {
     class CAManBase {
         class AI_Dynamic_Skill {
-            init = "(_this select 0) call AI_Dynamic_Skill_fnc_updateSkills";
+            init = "(_this select 0) call AI_Dynamic_Skill_fnc_scheduleInitSkills";
         };
     };
 };

--- a/addons/ai_dynamic_skill/fn_scheduleInitSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_scheduleInitSkills.sqf
@@ -1,0 +1,21 @@
+/*
+ * when a unit is spawned and the init EH fires, all its skills are set to 0
+ * - some time later (after our EH runs), some game logic sets the skills to
+ * the default 0.5, potentially overriding what we would have set
+ *
+ * this makes us unable to detect if this foreign skill modification was done
+ * by a user via Zeus or by this arbitrary logic
+ *
+ * therefore do a special procedure on unit init and allow any other invocation
+ * (from another EH or periodically) only after this special procedure has
+ * completed
+ */
+
+0 = _this spawn {
+    /* wait for the skills to become 0.5, account for dedi server rounding */
+    waitUntil { abs ((_this skill "general")-0.5) < 1e-2 };
+
+    /* unblock updateSkills and call it */
+    _this setVariable ["AI_Dynamic_Skill_initialized", true];
+    isNil { _this call AI_Dynamic_Skill_fnc_updateSkills };
+};

--- a/addons/ai_dynamic_skill/fn_setSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_setSkills.sqf
@@ -3,8 +3,7 @@ _this params ["_unit", "_skills"];
     private _name = _x;
     private _val = _skills select _forEachIndex;
 
-    if (time < 600) then {
-        /* atomic, prevents other mods from interfering */
+    if (time < 600 && {time > 60 && isDedicated}) then {
         private ["_set", "_final"];
 
         _unit setSkill [_name, _val];

--- a/addons/ai_dynamic_skill/fn_setSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_setSkills.sqf
@@ -6,11 +6,10 @@ _this params ["_unit", "_skills"];
     if (time < 600) then {
         /* atomic, prevents other mods from interfering */
         private ["_set", "_final"];
-        isNil {
-            _unit setSkill [_name, _val];
-            _set = _unit skill _name;
-            _final = _unit skillFinal _name;
-        };
+
+        _unit setSkill [_name, _val];
+        _set = _unit skill _name;
+        _final = _unit skillFinal _name;
 
         /*
          * val >= 0.2: because our CfgAISkill override doesn't guarantee anything

--- a/addons/ai_dynamic_skill/fn_updateSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_updateSkills.sqf
@@ -66,12 +66,6 @@ if (faction _unit in _guerrilla_factions) then {
     _aimingShake = 1.0;
 };
 
-/*
- * further increase Parkinson's based on suppression (no lower than 0.2)
- */
-private _supp = getSuppression _unit min 1;
-_aimingShake = (_aimingShake * (1 - _supp)) max 0.2;
-
 _aimingSpeed = 0.95;
 _endurance = 1.0;
 _spotDistance = 1.0;

--- a/addons/ai_dynamic_skill/fn_updateSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_updateSkills.sqf
@@ -9,6 +9,8 @@ private _unit = _this;
 private _initialized = _unit getVariable "AI_Dynamic_Skill_initialized";
 if (isNil "_initialized") exitWith {};
 
+if (!alive _unit || isPlayer _unit) exitWith {};
+
 private _prev = _unit getVariable "AI_Dynamic_Skill_prevskills";
 private _curr = _unit call AI_Dynamic_Skill_fnc_currentSkills;
 /* if _prev are not identical to current skills, user has modified them, exit */

--- a/addons/ai_dynamic_skill/fn_updateSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_updateSkills.sqf
@@ -101,5 +101,4 @@ private _skills = [
 [_unit, _skills] call AI_Dynamic_Skill_fnc_setSkills;
 
 /* set new "prev" skills */
-private _curr = _unit call AI_Dynamic_Skill_fnc_currentSkills;
-_unit setVariable ["AI_Dynamic_Skill_prevskills", _curr];
+_unit setVariable ["AI_Dynamic_Skill_prevskills", _skills];

--- a/addons/ai_dynamic_skill/fn_updateSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_updateSkills.sqf
@@ -6,6 +6,9 @@ if (!isServer) exitWith {};
 
 private _unit = _this;
 
+private _initialized = _unit getVariable "AI_Dynamic_Skill_initialized";
+if (isNil "_initialized") exitWith {};
+
 private _prev = _unit getVariable "AI_Dynamic_Skill_prevskills";
 private _curr = _unit call AI_Dynamic_Skill_fnc_currentSkills;
 /* if _prev are not identical to current skills, user has modified them, exit */

--- a/addons/ai_dynamic_skill/fn_watchSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_watchSkills.sqf
@@ -16,9 +16,7 @@ if (!isServer) exitWith {};
             {
                 /* unscheduled/atomic, in case something deletes the unit */
                 isNil {
-                    if (alive _x) then {  /* also !isNull */
-                        _x call AI_Dynamic_Skill_fnc_updateSkills;
-                    };
+                    _x call AI_Dynamic_Skill_fnc_updateSkills;
                 };
                 sleep _slp;
             } forEach _ents;


### PR DESCRIPTION
The original code doesn't work well with dedicated servers due to multiple reasons, the two main being `getSuppression` returning an invalid value due to non-local units and `skill` initially returning 0 when a unit is created on a client (ie. spawned by zeus).

Details provided either in individual commit messages or block code comments.