### PR TITLE
More fixes for ai_dynamic_skill, optimizations and working warnings

### DIFF
--- a/addons/ai_dynamic_skill/config.cpp
+++ b/addons/ai_dynamic_skill/config.cpp
@@ -20,6 +20,7 @@ class CfgFunctions {
             file = "\ai_dynamic_skill";
             class setSkills;
             class updateSkills;
+            class updateSkillsUnscheduled;
             class watchSkills { postInit = 1; };
             class currentSkills;
             class scheduleInitSkills;
@@ -37,21 +38,21 @@ class Extended_Init_Eventhandlers {
 class Extended_GetInMan_Eventhandlers {
     class CAManBase {
         class AI_Dynamic_Skill {
-            getinman = "isNil { (_this select 0) call AI_Dynamic_Skill_fnc_updateSkills }";
+            getinman = "(_this select 0) call AI_Dynamic_Skill_fnc_updateSkills";
         };
     };
 };
 class Extended_GetOutMan_Eventhandlers {
     class CAManBase {
         class AI_Dynamic_Skill {
-            getoutman = "isNil { (_this select 0) call AI_Dynamic_Skill_fnc_updateSkills }";
+            getoutman = "(_this select 0) call AI_Dynamic_Skill_fnc_updateSkills";
         };
     };
 };
 class Extended_SeatSwitchedMan_Eventhandlers {
     class CAManBase {
         class AI_Dynamic_Skill {
-            seatswitchedman = "isNil { (_this select 0) call AI_Dynamic_Skill_fnc_updateSkills }";
+            seatswitchedman = "(_this select 0) call AI_Dynamic_Skill_fnc_updateSkills";
         };
     };
 };

--- a/addons/ai_dynamic_skill/config.cpp
+++ b/addons/ai_dynamic_skill/config.cpp
@@ -72,7 +72,13 @@ class CfgVehicles {
 };
 #endif
 
-/* linear X=Y from 0.2 up, don't ask how, took 3 days of research */
+/*
+ * linear X=Y from 0.2 up, don't ask how, took 3 days of research
+ * https://drive.google.com/open?id=1GDzxZpVa1IDFP9GAeHUVrKIiGqKR5jv68qvE-0JhMQ0
+ *
+ * default UI slider ranges in Eden / Zeus are 0.2 to 1.0, so the user won't set
+ * values below 0.2 via UI
+ */
 class CfgAISkill {
     aimingAccuracy[] = {0,0, 0.5,0, 1,1};
     aimingShake[]    = {0,0, 0.5,0, 1,1};
@@ -84,20 +90,4 @@ class CfgAISkill {
     reloadSpeed[]    = {0,0, 0.5,0, 1,1};
     commanding[]     = {0,0, 0.5,0, 1,1};
     general[]        = {0,0, 0.5,0, 1,1};
-};
-
-class Cfg3DEN {
-    class Attributes {
-        class Slider;
-        class Controls;
-        class Value;
-        /* allow full 0-1 setting, not just 0.2-1 */
-        class Skill : Slider {
-            class Controls : Controls {
-                class Value : Value {
-                    sliderRange[] = {0, 1};
-                };
-            };
-        };
-    };
 };

--- a/addons/ai_dynamic_skill/fn_scheduleInitSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_scheduleInitSkills.sqf
@@ -17,5 +17,5 @@
 
     /* unblock updateSkills and call it */
     _this setVariable ["AI_Dynamic_Skill_initialized", true];
-    isNil { _this call AI_Dynamic_Skill_fnc_updateSkills };
+    _this call AI_Dynamic_Skill_fnc_updateSkills;
 };

--- a/addons/ai_dynamic_skill/fn_scheduleInitSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_scheduleInitSkills.sqf
@@ -13,7 +13,7 @@
 
 0 = _this spawn {
     /* wait for the skills to become 0.5, account for dedi server rounding */
-    waitUntil { abs ((_this skill "general")-0.5) < 1e-2 };
+    waitUntil { abs ((_this skill "general")-0.5) < 0.05 };
 
     /* unblock updateSkills and call it */
     _this setVariable ["AI_Dynamic_Skill_initialized", true];

--- a/addons/ai_dynamic_skill/fn_updateSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_updateSkills.sqf
@@ -2,97 +2,10 @@
  * dynamically update skills of a unit
  */
 
-if (!isServer) exitWith {};
-
-private _unit = _this;
-
-private _initialized = _unit getVariable "AI_Dynamic_Skill_initialized";
+/* some easy checks that don't need atomic context */
+if (!isServer || !simulationEnabled _this || isPlayer _this) exitWith {};
+private _initialized = _this getVariable "AI_Dynamic_Skill_initialized";
 if (isNil "_initialized") exitWith {};
 
-if (!alive _unit || isPlayer _unit) exitWith {};
-
-private _prev = _unit getVariable "AI_Dynamic_Skill_prevskills";
-private _curr = _unit call AI_Dynamic_Skill_fnc_currentSkills;
-/* if _prev are not identical to current skills, user has modified them, exit */
-if (!isNil "_prev" && {!(_prev isEqualTo _curr)}) exitWith {};
-
-private [
-    "_aimingAccuracy",
-    "_aimingShake",
-    "_aimingSpeed",
-    "_endurance",
-    "_spotDistance",
-    "_spotTime",
-    "_courage",
-    "_reloadSpeed",
-    "_commanding",
-    "_general"
-];
-
-
-/*
- * make infantry fairly accurate, vehicles more so
- * (avoid >=0.9 for vehicles as it makes them single-shoot MGs)
- */
-private _veh = vehicle _unit;
-if (_veh != _unit && {_unit in [driver _veh, gunner _veh, commander _veh]}) then {
-    if (_veh isKindOf "Car") then {
-        _aimingAccuracy = 0.6;
-    } else {
-        _aimingAccuracy = 0.7;
-    };
-    /* when in COMBAT, don't exit a vehicle if it becomes immobilized */
-    if (behaviour _unit == "COMBAT") then {
-        _veh allowCrewInImmobile true;
-    } else {
-        _veh allowCrewInImmobile false;
-    };
-} else {
-    _aimingAccuracy = 0.5;
-};
-
-/*
- * give slight Parkinson's to guerrilla factions when shooting
- */
-private _guerrilla_factions = [
-    "BLU_G_F", "IND_G_F", "OPF_G_F", "CIV_F",
-    "rhs_faction_insurgents", "rhsgref_faction_chdkz", "rhsgref_faction_chdkz_g",
-    "LOP_AFR", "LOP_AFR_Civ", "LOP_AFR_OPF", "LOP_AM", "LOP_AM_OPF", "LOP_BH",
-    "LOP_ChDKZ", "LOP_CHR_Civ", "LOP_NAPA", "LOP_TAK_Civ", "LOP_UA", "LOP_UVF"
-];
-if (faction _unit in _guerrilla_factions) then {
-    _aimingShake = 0.4;
-} else {
-    _aimingShake = 1.0;
-};
-
-_aimingSpeed = 0.95;
-_endurance = 1.0;
-_spotDistance = 1.0;
-
-/*
- * react slower to visual contact outside combat
- * (allow enemies to ie. reposition between trees, don't spot them instantly
- *  as they leave hard cover)
- */
-_spotTime = switch (behaviour _unit) do {
-    case "STEALTH";
-    case "AWARE":  { 0.7 };
-    case "COMBAT": { 0.95 };
-    default { 0.5 };
-};
-
-_courage = 0.6;   /* allows retreat when under fire */
-_reloadSpeed = 1.0;
-_commanding = 1.0;
-_general = 1.0;
-
-
-private _skills = [
-    _aimingAccuracy, _aimingShake, _aimingSpeed, _endurance, _spotDistance,
-    _spotTime, _courage, _reloadSpeed, _commanding, _general
-];
-[_unit, _skills] call AI_Dynamic_Skill_fnc_setSkills;
-
-/* set new "prev" skills */
-_unit setVariable ["AI_Dynamic_Skill_prevskills", _skills];
+/* unscheduled/atomic, in case something deletes the unit */
+isNil { _this call AI_Dynamic_Skill_fnc_updateSkillsUnscheduled };

--- a/addons/ai_dynamic_skill/fn_updateSkillsUnscheduled.sqf
+++ b/addons/ai_dynamic_skill/fn_updateSkillsUnscheduled.sqf
@@ -1,0 +1,98 @@
+/*
+ * run in unscheduled environment to avoid scripting errors of commands
+ * accessing a deleted unit (ie.)
+ */
+
+private _unit = _this;
+
+if (!alive _unit) exitWith {};
+
+private _prev = _unit getVariable "AI_Dynamic_Skill_prevskills";
+private _curr = _unit call AI_Dynamic_Skill_fnc_currentSkills;
+/* if _prev are not identical to current skills, user has modified them, exit */
+if (!isNil "_prev" && {!(_prev isEqualTo _curr)}) exitWith {};
+
+private [
+    "_aimingAccuracy",
+    "_aimingShake",
+    "_aimingSpeed",
+    "_endurance",
+    "_spotDistance",
+    "_spotTime",
+    "_courage",
+    "_reloadSpeed",
+    "_commanding",
+    "_general"
+];
+
+/* -------------------------------------------------------------------------- */
+
+
+/*
+ * make infantry fairly accurate, vehicles more so
+ * (avoid >=0.9 for vehicles as it makes them single-shoot MGs)
+ */
+private _veh = vehicle _unit;
+if (_veh != _unit && {_unit in [driver _veh, gunner _veh, commander _veh]}) then {
+    if (_veh isKindOf "Car") then {
+        _aimingAccuracy = 0.6;
+    } else {
+        _aimingAccuracy = 0.7;
+    };
+    /* when in COMBAT, don't exit a vehicle if it becomes immobilized */
+    if (behaviour _unit == "COMBAT") then {
+        _veh allowCrewInImmobile true;
+    } else {
+        _veh allowCrewInImmobile false;
+    };
+} else {
+    _aimingAccuracy = 0.5;
+};
+
+/*
+ * give slight Parkinson's to guerrilla factions when shooting
+ */
+private _guerrilla_factions = [
+    "BLU_G_F", "IND_G_F", "OPF_G_F", "CIV_F",
+    "rhs_faction_insurgents", "rhsgref_faction_chdkz", "rhsgref_faction_chdkz_g",
+    "LOP_AFR", "LOP_AFR_Civ", "LOP_AFR_OPF", "LOP_AM", "LOP_AM_OPF", "LOP_BH",
+    "LOP_ChDKZ", "LOP_CHR_Civ", "LOP_NAPA", "LOP_TAK_Civ", "LOP_UA", "LOP_UVF"
+];
+if (faction _unit in _guerrilla_factions) then {
+    _aimingShake = 0.4;
+} else {
+    _aimingShake = 1.0;
+};
+
+_aimingSpeed = 0.95;
+_endurance = 1.0;
+_spotDistance = 1.0;
+
+/*
+ * react slower to visual contact outside combat
+ * (allow enemies to ie. reposition between trees, don't spot them instantly
+ *  as they leave hard cover)
+ */
+_spotTime = switch (behaviour _unit) do {
+    case "STEALTH";
+    case "AWARE":  { 0.7 };
+    case "COMBAT": { 0.95 };
+    default { 0.5 };
+};
+
+_courage = 0.6;   /* allows retreat when under fire */
+_reloadSpeed = 1.0;
+_commanding = 1.0;
+_general = 1.0;
+
+
+/* -------------------------------------------------------------------------- */
+
+private _skills = [
+    _aimingAccuracy, _aimingShake, _aimingSpeed, _endurance, _spotDistance,
+    _spotTime, _courage, _reloadSpeed, _commanding, _general
+];
+[_unit, _skills] call AI_Dynamic_Skill_fnc_setSkills;
+
+/* set new "prev" skills */
+_unit setVariable ["AI_Dynamic_Skill_prevskills", _skills];

--- a/addons/ai_dynamic_skill/fn_watchSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_watchSkills.sqf
@@ -15,10 +15,7 @@ if (!isServer) exitWith {};
         if (_cnt > 0) then {
             private _slp = 10 / _cnt;
             {
-                /* unscheduled/atomic, in case something deletes the unit */
-                isNil {
-                    _x call AI_Dynamic_Skill_fnc_updateSkills;
-                };
+                _x call AI_Dynamic_Skill_fnc_updateSkills;
                 sleep _slp;
             } forEach _ents;
         };

--- a/addons/ai_dynamic_skill/fn_watchSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_watchSkills.sqf
@@ -11,8 +11,9 @@ if (!isServer) exitWith {};
     waitUntil {
         /* update skills of all units every ~10 seconds, spread out */
         private _ents = entities [["CAManBase"], [], true, true] - allPlayers;
-        if (count _ents > 0) then {
-            private _slp = 10 / count _ents;
+        private _cnt = count _ents;
+        if (_cnt > 0) then {
+            private _slp = 10 / _cnt;
             {
                 /* unscheduled/atomic, in case something deletes the unit */
                 isNil {


### PR DESCRIPTION
See commit messages for details, ... this should be the final batch of fixes, hopefully.

Note that warnings may appear if `CustomAILevel` is not set correctly according to the README, whereas in the previous (current master) version, a bug (copy/paste from legacy code) prevented them from showing up.