### PR TITLE
Bogus warning fix for ai_dynamic_skill

### DIFF
--- a/addons/ai_dynamic_skill/config.cpp
+++ b/addons/ai_dynamic_skill/config.cpp
@@ -24,6 +24,7 @@ class CfgFunctions {
             class watchSkills { postInit = 1; };
             class currentSkills;
             class scheduleInitSkills;
+            class warnBadCfg;
         };
     };
 };

--- a/addons/ai_dynamic_skill/fn_setSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_setSkills.sqf
@@ -1,45 +1,16 @@
 _this params ["_unit", "_skills"];
 
-#define SKILLS "aimingAccuracy", "aimingShake", "aimingSpeed", "endurance", \
-               "spotDistance", "spotTime", "courage", "reloadSpeed", \
-               "commanding", "general"
-
 {
     _unit setSkill [_x, _skills select _forEachIndex];
-} forEach [ SKILLS ];
-
-/* verify CustomAILevel Arma3Profile setting during the first 10 minutes */
-if (time < 600 && {time > 60 && isDedicated}) then {
-    private ["_skill", "_final"];
-
-    if (isNil "AI_Dynamic_Skill_latest_warning") then {
-	AI_Dynamic_Skill_latest_warning = 0;
-    };
-
-    if (time - AI_Dynamic_Skill_latest_warning > 10) then {
-        {
-            private _name = _x;
-            private _val = _skills select _forEachIndex;
-    
-            _skill = _unit skill _name;
-            _final = _unit skillFinal _name;
-    
-            /*
-             * val >= 0.2: because our CfgAISkill override doesn't guarantee anything
-             *             below 0.2, due to engine limitations of CfgAISkill
-             * set > 0:    because we cannot distinguish between createVehicle and
-             *             createUnit, the latter having initially skill/skillFinal 0
-             * abs check:  because of floating point MP errors in the final skill
-             */
-            if (_val >= 0.2 && _skill > 0 && abs (_val-_final) > 0.05) then {
-                private _msg = format [
-                    "ai_dynamic_skill: skill %1 is %2, but skillFinal is %3",
-                    _name, _val toFixed 2, _final toFixed 2
-                ];
-                _msg remoteExec ["systemChat"];
-                diag_log _msg;
-            };
-        } forEach [ SKILLS ];
-        AI_Dynamic_Skill_latest_warning = time;
-    };
-};
+} forEach [
+    "aimingAccuracy",
+    "aimingShake",
+    "aimingSpeed",
+    "endurance",
+    "spotDistance",
+    "spotTime",
+    "courage",
+    "reloadSpeed",
+    "commanding",
+    "general"
+];

--- a/addons/ai_dynamic_skill/fn_updateSkillsUnscheduled.sqf
+++ b/addons/ai_dynamic_skill/fn_updateSkillsUnscheduled.sqf
@@ -61,7 +61,7 @@ private _guerrilla_factions = [
 if (faction _unit in _guerrilla_factions) then {
     _aimingShake = 0.4;
 } else {
-    _aimingShake = 1.0;
+    _aimingShake = 0.9;  /* 1.0 seems to do unnatural insta-headshot-kills */
 };
 
 _aimingSpeed = 0.95;

--- a/addons/ai_dynamic_skill/fn_warnBadCfg.sqf
+++ b/addons/ai_dynamic_skill/fn_warnBadCfg.sqf
@@ -1,0 +1,53 @@
+/*
+ * verify CustomAILevel Arma3Profile setting during the first 10 minutes
+ */
+
+if (time > 600) exitWith {};
+if (time < 60 || !isDedicated) exitWith {};
+
+private _unit = _this;
+
+if (isNil "AI_Dynamic_Skill_latest_warning") then {
+    AI_Dynamic_Skill_latest_warning = 0;
+};
+if (time - AI_Dynamic_Skill_latest_warning < 10) exitWith {};
+
+{
+    private _name = _x;
+
+    /* atomic, just in case the skill is modified from elsewhere */
+    private ["_skill", "_final"];
+    isNil {
+        _skill = _unit skill _name;
+        _final = _unit skillFinal _name;
+    };
+
+    /*
+     * val >= 0.2: because our CfgAISkill override doesn't guarantee anything
+     *             below 0.2, due to engine limitations of CfgAISkill
+     * set > 0:    because we cannot distinguish between createVehicle and
+     *             createUnit, the latter having initially skill/skillFinal 0
+     * abs check:  because of floating point MP errors in the final skill
+     */
+    if (_skill >= 0.2 && _skill > 0 && abs (_skill-_final) > 0.05) then {
+        private _msg = format [
+            "ai_dynamic_skill: skill %1 is %2, but skillFinal is %3",
+            _name, _skill toFixed 2, _final toFixed 2
+        ];
+        _msg remoteExec ["systemChat"];
+        diag_log _msg;
+    };
+} forEach [
+    "aimingAccuracy",
+    "aimingShake",
+    "aimingSpeed",
+    "endurance",
+    "spotDistance",
+    "spotTime",
+    "courage",
+    "reloadSpeed",
+    "commanding",
+    "general"
+];
+
+AI_Dynamic_Skill_latest_warning = time;

--- a/addons/ai_dynamic_skill/fn_watchSkills.sqf
+++ b/addons/ai_dynamic_skill/fn_watchSkills.sqf
@@ -16,6 +16,7 @@ if (!isServer) exitWith {};
             private _slp = 10 / _cnt;
             {
                 _x call AI_Dynamic_Skill_fnc_updateSkills;
+                _x call AI_Dynamic_Skill_fnc_warnBadCfg;
                 sleep _slp;
             } forEach _ents;
         };


### PR DESCRIPTION
(I know I said the last is going to be the last.)

This fixes the 0.50 skill bogus warning when spawning a first unit on a mission, if spawned between 60 and 600 seconds after mission start. Also adjusts default shake to be less terminator-y.

See individual commit messages.