### PR TITLE
static_line_chute: parachutes, automated

### DIFF
--- a/addons/static_line_chute/config.cpp
+++ b/addons/static_line_chute/config.cpp
@@ -1,0 +1,35 @@
+/*
+ * various Arma 3 Spectator related tweaks and configuration
+ */
+
+class CfgPatches {
+    class Static_Line_Chute {
+        units[] = {};
+        weapons[] = {};
+        requiredAddons[] = { "rhs_c_troops" };
+    };
+};
+
+class CfgVehicles {
+    /* make D6 fall more vertically than a glider */
+    class Steerable_Parachute_F;
+    class rhs_d6_Parachute : Steerable_Parachute_F {
+        ace_hasReserveParachute = 0;
+        ace_reserveParachute = "";
+        airInfluence = 0.1;
+    };
+};
+
+class CfgFunctions {
+    class Static_Line_Chute {
+        class All {
+            file = "\static_line_chute";
+            class createACEAction;
+            class addActionToVehicles { postInit = 1; };
+            class getPassengers;
+            class ejectWithChute;
+            class ejectUnits;
+            class vehicleChat;
+        };
+    };
+};

--- a/addons/static_line_chute/fn_addActionToVehicles.sqf
+++ b/addons/static_line_chute/fn_addActionToVehicles.sqf
@@ -1,0 +1,9 @@
+/*
+ * add ACE interaction actions to air vehicles capable of static line jump
+ */
+
+private _root_action = [] call Static_Line_Chute_fnc_createACEAction;
+
+{
+    [_x, 1, ["ACE_SelfActions"], _root_action, true] call ace_interact_menu_fnc_addActionToClass;
+} forEach ["Plane", "Helicopter"];

--- a/addons/static_line_chute/fn_createACEAction.sqf
+++ b/addons/static_line_chute/fn_createACEAction.sqf
@@ -1,0 +1,88 @@
+/*
+ * create ACE3 menu tree for the pilot/crew
+ */
+
+Static_Line_Chute_fnc_menu_children_grouplist = {
+    params ["_target", "_player", "_params"];
+    private _children = [];
+
+    /* get list of groups onboard */
+    private _cargo = _target call Static_Line_Chute_fnc_getPassengers;
+    private _unique_groups = [];
+    {
+        _unique_groups pushBackUnique (group _x);
+    } forEach _cargo;
+
+    {
+        private _action = [
+            format ["Static_Line_Chute_Jump_jumpall_grp_%1", groupId _x],
+            groupId _x,
+            "",
+            {
+                params ["_target", "_player", "_params"];
+                [_target, _params] call Static_Line_Chute_fnc_ejectUnits;
+            },
+            { true },
+            {},
+            _x
+        ] call ace_interact_menu_fnc_createAction;
+        _children pushBack [_action, [], _target];
+    } forEach _unique_groups;
+
+    _children;
+};
+
+Static_Line_Chute_fnc_menu_children_all_or_group = {
+    params ["_target", "_player", "_params"];
+    private _children = [];
+
+    private _jump_all = [
+        "Static_Line_Chute_Jump_jumpall",
+        "All Passengers",
+        "z\ace\addons\interaction\UI\team\team_management_ca.paa",
+        {
+            params ["_target", "_player", "_params"];
+            _target call Static_Line_Chute_fnc_ejectUnits;
+        },
+        { true }
+    ] call ace_interact_menu_fnc_createAction;
+
+    private _jump_group = [
+        "Static_Line_Chute_Jump_jumpgrp",
+        "Only Group",
+        "z\ace\addons\interaction\UI\team\team_white_ca.paa",
+        {},
+        { true },
+        Static_Line_Chute_fnc_menu_children_grouplist
+    ] call ace_interact_menu_fnc_createAction;
+
+    [
+        [_jump_all, [], _target],
+        [_jump_group, [], _target]
+    ];
+};
+
+private _action = [
+    "Static_Line_Chute_Jump",
+    "Static Line Jump",
+    "\a3\ui_f\data\gui\cfg\CommunicationMenu\supplydrop_ca.paa",
+    {},
+    {
+        /* only non-cargo crew can initiate the jump */
+        ((_this select 0) getCargoIndex (_this select 1)) < 0
+        /* above 100m */
+        && position (_this select 0) select 2 > 100
+        /* only when not already in progress */
+        && !((_this select 0) getVariable ["Static_Line_Chute_jumping", false])
+        /* only with non-zero passengers */
+        && count ((_this select 0) call Static_Line_Chute_fnc_getPassengers) > 0
+        /* only in vehicles with cargo/turret space above 8 */
+        && count (
+            fullCrew [(_this select 0), "turret", true]    /* includes copilot! */
+            + fullCrew [(_this select 0), "cargo", true]
+           ) >= 9
+    },
+    Static_Line_Chute_fnc_menu_children_all_or_group
+] call ace_interact_menu_fnc_createAction;
+
+_action;

--- a/addons/static_line_chute/fn_ejectUnits.sqf
+++ b/addons/static_line_chute/fn_ejectUnits.sqf
@@ -1,0 +1,46 @@
+/*
+ * eject passengers from vehicle, in reverse order
+ *
+ * eject only members of _group, if specified
+ */
+
+params ["_vehicle", ["_group", grpNull]];
+
+private _cargo = [_vehicle, _group] call Static_Line_Chute_fnc_getPassengers;
+
+/* jump */
+0 = [_vehicle, _cargo] spawn {
+    params ["_vehicle", "_cargo"];
+
+    private _spd = speed _vehicle;
+    private _delay = switch true do {
+        case (_spd > 200): {0.5};
+        case (_spd > 150): {1};
+        case (_spd > 100): {2};
+        case (_spd > 50):  {4};
+        default            {6};
+    };
+
+    private _total = count _cargo;
+
+    _vehicle setVariable ["Static_Line_Chute_jumping", true, true];
+    {
+        if (!alive _vehicle) exitWith {};
+
+        /* relay status messages to crew */
+        [
+            _vehicle,
+            format ["Jumping %1/%2: %3 (%4)",
+                    _forEachIndex+1, _total, name _x, groupId group _x]
+        ] call Static_Line_Chute_fnc_vehicleChat;
+
+        [_vehicle, _x] remoteExec ["Static_Line_Chute_fnc_ejectWithChute", _x];
+
+        if (_forEachIndex < _total -1) then {
+            sleep _delay;
+        };
+    } forEach _cargo;
+    _vehicle setVariable ["Static_Line_Chute_jumping", nil, true];
+
+    [_vehicle, "Jump Done."] call Static_Line_Chute_fnc_vehicleChat;
+};

--- a/addons/static_line_chute/fn_ejectWithChute.sqf
+++ b/addons/static_line_chute/fn_ejectWithChute.sqf
@@ -1,0 +1,16 @@
+/*
+ * eject the unit and immediately open a parachute (if any)
+ */
+
+0 = _this spawn {
+    params ["_src_vehicle", "_unit"];
+    if (vehicle _unit != _src_vehicle) exitWith {};
+
+    private _veh = vehicle _unit;
+    /* Eject would spawn parachute for AI, GetOut works for both */
+    _unit action ["GetOut", _veh];
+    /* account for possible lag between action and effect */
+    waitUntil { vehicle _unit != _veh };
+    sleep 1;
+    _unit action ["OpenParachute", _unit];
+};

--- a/addons/static_line_chute/fn_getPassengers.sqf
+++ b/addons/static_line_chute/fn_getPassengers.sqf
@@ -1,0 +1,30 @@
+/*
+ * get all cargo/turret units, sorted by cargo idx
+ *
+ * (because the "crew" command prefers turrets)
+ *
+ * filter by _group, if specified
+ */
+
+params ["_vehicle", ["_group", grpNull]];
+
+private _cargo = [];
+{
+    private _idx = _vehicle getCargoIndex _x;
+    if (_idx >= 0) then {
+        _cargo set [_idx, _x];
+    };
+} forEach crew _vehicle;
+
+/* remove <null> and limit to one group, if specified */
+_cargo = _cargo select {
+    /* remove <null> members, empty seats */
+    !isNull _x
+    /* limit to one group, if specified */
+    && {isNull _group || group _x == _group}
+    /* no ACE prisoners or ACE unconscious units */
+    && !(_x getVariable ["ace_captives_isHandcuffed", false])
+    && !(_x getVariable ["ACE_isUnconscious", false])
+};
+
+_cargo;

--- a/addons/static_line_chute/fn_vehicleChat.sqf
+++ b/addons/static_line_chute/fn_vehicleChat.sqf
@@ -1,0 +1,14 @@
+/*
+ * send a message to members of a given vehicle (incl. remote control)
+ */
+
+[_this, {
+    params ["_vehicle", "_msg"];
+    if (ace_player in crew _vehicle) then {
+        systemChat _msg;
+    };
+}] remoteExec ["call"];
+/*
+ * don't use array of objects here in remoteExec, the code gets executed for
+ * each of the objects, not only once where (any) of them are local
+ */


### PR DESCRIPTION
Static line:

- done as ACE menu item visible to crew (pilot, copilot, gunner,
  commander, but not to passengers)

- the ACE menu item shows only in airplanes and helicopters with enough
  seats (9 or more "passenger" spaces, which confusingly includes
  copilot (not a pilot/driver) and crew chief (not gunner))
  https://i.imgur.com/4jiNPyQ.jpg

- the ACE menu item is also limited to >100m for safety reasons

- ejects all passengers (in cargo and "turrets" - units able to shoot
  with small arms) or individual groups

- ejection order is cargo index order (vehicle boarding order),
  but reversed (LIFO)

- delay between ejected units depends on speed (see code)

- handcuffed and unconscious units are ignored

- ejection progress is indicated via chat to all units still inside
  the vehicle, the ACE menu item is disabled for the duration of the
  deployment (to prevent accidents)

RHS D6 parachute changes:

- adjusted to fall more vertically (like a dome chute should) instead of
  gliding like vanilla steerable parachute

- reserve parachute disabled as ACE Reserve Parachute is identical to
  vanilla steerable parachute and for ease of use (so that landed units
  don't carry one on their back)

Signed-off-by: freghar <freghar@dummy.tld>