### PR TITLE
static_line_chute: allow high rank to initiate the jump

### DIFF
--- a/addons/static_line_chute/fn_createACEAction.sqf
+++ b/addons/static_line_chute/fn_createACEAction.sqf
@@ -68,8 +68,11 @@ private _action = [
     "\a3\ui_f\data\gui\cfg\CommunicationMenu\supplydrop_ca.paa",
     {},
     {
-        /* only non-cargo crew can initiate the jump */
-        ((_this select 0) getCargoIndex (_this select 1)) < 0
+        /* only non-cargo crew (or high rank) can initiate the jump */
+        (
+            ((_this select 0) getCargoIndex (_this select 1)) < 0
+            || rankId (_this select 1) >= 3
+        )
         /* above 100m */
         && position (_this select 0) select 2 > 100
         /* only when not already in progress */

--- a/addons/static_line_chute/fn_getPassengers.sqf
+++ b/addons/static_line_chute/fn_getPassengers.sqf
@@ -16,7 +16,6 @@ private _cargo = [];
     };
 } forEach crew _vehicle;
 
-/* remove <null> and limit to one group, if specified */
 _cargo = _cargo select {
     /* remove <null> members, empty seats */
     !isNull _x


### PR DESCRIPTION
This should allow Lieutenants (our squad leaders) and above to initiate
the jump in the absence of a player/zeus controlled vehicle crew.

Also remove a redundant code comment.

Signed-off-by: freghar <freghar@dummy.tld>