### PR TITLE
editor_extensions: fix attachTo module rotation

### DIFF
--- a/addons/editor_extensions/modules/functions/fn_attachSynced.sqf
+++ b/addons/editor_extensions/modules/functions/fn_attachSynced.sqf
@@ -17,9 +17,7 @@ if (is3DEN) exitWith {};
     _synced deleteAt 0;
 
     {
-        private _dir = getDir _x;
-        _x attachTo [_target];
-        _x setDir (_dir - getDir _x);
+        [_x, _target] call BIS_fnc_attachToRelative;
     } forEach _synced;
 
     deleteVehicle _this;


### PR DESCRIPTION
Fix complex rotation not being applied properly.
BIS_fnc_attachToRelative fixes this all.

Example in editor:
![editor](https://user-images.githubusercontent.com/15021889/102502151-91235180-407e-11eb-8cb2-5eca77dd0993.jpg)

Old functionality:
![old](https://user-images.githubusercontent.com/15021889/102502171-97b1c900-407e-11eb-9636-eb46c9a15297.jpg)

Fixed rotation:
![updated](https://user-images.githubusercontent.com/15021889/102502182-9b455000-407e-11eb-8414-c239a1c2f279.jpg)


